### PR TITLE
typo removed in `create_certs.sh`

### DIFF
--- a/create_certs.sh
+++ b/create_certs.sh
@@ -39,18 +39,20 @@ length=${#arrIN[@]}
 
 for i in "${arrIN[@]}"; do
     # process "$i"
-    if (( k > 1 )) && (( k < length - 1 ))
+    if (( $k > 1 )) && (( $k < $length - 1 ))
     then
       modulus=$modulus$i
     fi
 
-    if (( k == length -1 ))
+    if (( $k == $length -1 ))
     then
       exponent=$i
     fi
 
-    k=$((k+1))
+    k=$(($k+1))
 done
+echo $modulus
+echo $exponent
 
 modulus=${modulus//[: ]/}
 modulus="${modulus:2}"

--- a/create_certs.sh
+++ b/create_certs.sh
@@ -51,8 +51,6 @@ for i in "${arrIN[@]}"; do
 
     k=$(($k+1))
 done
-echo $modulus
-echo $exponent
 
 modulus=${modulus//[: ]/}
 modulus="${modulus:2}"


### PR DESCRIPTION
There was a typo in `create_certs.sh`. `$` sign was missing before variables.